### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/bxrne/logmgr/security/code-scanning/4](https://github.com/bxrne/logmgr/security/code-scanning/4)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will apply to all jobs in the workflow unless overridden by job-specific `permissions` blocks. Since the workflow primarily involves reading repository contents (e.g., checking out code, downloading dependencies, and running tests), the minimal required permission is `contents: read`. This change ensures that the `GITHUB_TOKEN` is restricted to read-only access, adhering to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
