### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   lint:
     name: Lint
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -25,6 +27,8 @@ jobs:
 
   test:
     name: Test
+    permissions:
+      contents: read
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
@@ -68,6 +72,8 @@ jobs:
 
   build:
     name: Build
+    permissions:
+      contents: read
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]


### PR DESCRIPTION
Potential fix for [https://github.com/bxrne/logmgr/security/code-scanning/3](https://github.com/bxrne/logmgr/security/code-scanning/3)

To fix the issue, we need to explicitly define the permissions for the `Test` job and other jobs in the workflow. The permissions block should specify the least privileges required for each job. For the `Test` job, `contents: read` is sufficient since it only needs to read repository contents to run tests and upload coverage reports. Similarly, the `Lint` and `Build` jobs should also have their permissions explicitly defined.

The permissions block can be added at the root level of the workflow to apply to all jobs or at the job level for more granular control. In this case, we will add job-specific permissions to ensure each job has only the permissions it needs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
