### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint


### PR DESCRIPTION
Potential fix for [https://github.com/bxrne/logmgr/security/code-scanning/2](https://github.com/bxrne/logmgr/security/code-scanning/2)

To fix the issue, we will add a `permissions` block to the workflow. This block will be added at the root level of the workflow to apply to all jobs. Based on the actions used in the workflow, the minimal required permissions are `contents: read`. This ensures that the workflow has only the necessary access to repository contents and no unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
