### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,5 +1,8 @@
 name: SonarCloud Analysis
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/bxrne/logmgr/security/code-scanning/1](https://github.com/bxrne/logmgr/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function securely. Based on the workflow's steps, it primarily interacts with repository contents (e.g., checking out code and running tests) and uses the `GITHUB_TOKEN` for authentication with SonarCloud. Therefore, the `contents: read` permission is sufficient. No write permissions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
